### PR TITLE
let the live-reload only available in DEVELOP_MODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,13 @@ cmake_minimum_required(VERSION 2.8.12)
 project(GameHall LANGUAGES CXX)
 
 option(DEVELOP_MODE "enable develop mode" OFF)
-
 set(WATCH_DIR_PATH "\"${PROJECT_SOURCE_DIR}/script/QML\"")
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-message("Project Source Dir is:${WATCH_DIR_PATH}")
+message("The source Dir of this project is :${WATCH_DIR_PATH}")
 
 configure_file (
         "${PROJECT_SOURCE_DIR}/src/utils.h.in"
@@ -21,7 +21,7 @@ find_package(Qt5 COMPONENTS Core Quick REQUIRED)
 if(DEVELOP_MODE)
 	add_executable(${PROJECT_NAME} "src/main.cpp" "src/watchreload/watchreload.cpp" "src/watchreload/watchreload.h")
 else()
-	add_executable(${PROJECT_NAME} "src/main.cpp" "src/watchreload/watchreload.cpp" "src/watchreload/watchreload.h" "script/QML/qml.qrc")
+	add_executable(${PROJECT_NAME} "src/main.cpp" "script/QML/qml.qrc")
 endif()
 
 target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Quick)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,43 +1,47 @@
+#include <QDebug>
+#include <QFileSystemWatcher>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
-#include <QFileSystemWatcher>
-#include <QDebug>
-#include "watchreload/watchreload.h"
+
 #include "utils.h"
+#ifdef DEVELOP_MODE
+#include "watchreload/watchreload.h"
+#endif
 
 int main(int argc, char *argv[])
 {
-    // disable QML cache to prevent the associated bugs from manifesting
-    qputenv("QML_DISABLE_DISK_CACHE", "1");
-
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
-
-    // monitor the resource dir and output the dirname
-    QFileSystemWatcher watcher;
-
-    QString str = WATCH_DIR_PATH; // use Cmakelist.txt to pass a macro to this file
-    if (!watcher.addPath(str) ){
-        qDebug() << "Target path not found";
-    }
-    else {
-        QStringList list = watcher.directories();
-        qDebug() << "Watching dir list: "<< list[0].toUtf8().constData();
-    }
-
     QQmlApplicationEngine engine;
 
 #if defined(DEVELOP_MODE)
-    QString devPath = WATCH_DIR_PATH;
-    qputenv("QT_QUICK_CONTROLS_CONF", (devPath+"/qtquickcontrols2.conf").toUtf8());
-    engine.load(QUrl(devPath+"/main.qml"));
+    qDebug() << "DEVELOP_MODE=ON";
+    // monitor the resource dir and output the dirname
+    QFileSystemWatcher filewatcher;
+    QString watchPath = WATCH_DIR_PATH; // use Cmakelist.txt to pass a macro to this file
+    if (!filewatcher.addPath(watchPath) ){
+        qDebug() << "Target path not found";
+    }
+    else {
+        QStringList dirList = filewatcher.directories();
+        qDebug() << "Watching dir list: "<< dirList[0].toUtf8().constData();
+    }
+    // disable QML cache to prevent the associated bugs from manifesting
+    qputenv("QML_DISABLE_DISK_CACHE", "1");
+
+    QString confFilePath = WATCH_DIR_PATH;
+    QString mainQmlPath = WATCH_DIR_PATH;
+    confFilePath.append("/qtquickcontrols2.conf");
+    mainQmlPath.append("/main.qml");
+    qputenv("QT_QUICK_CONTROLS_CONF", (confFilePath).toUtf8());
+    engine.load(QUrl(mainQmlPath));
+    // a function as a slot to receive and react to the signal
+    WatchReload reloader(&engine);
+    QObject::connect(&filewatcher,&QFileSystemWatcher::directoryChanged,&reloader,&WatchReload::reload);
 #else
+    qDebug() << "DEVELOP_MODE=OFF";
     engine.load(QUrl(QLatin1String("qrc:/main.qml")));
 #endif
-
-    // a function as a slot to receive and react to the signal
-    WatchReload Reload(&engine);
-    QObject::connect(&watcher,&QFileSystemWatcher::directoryChanged,&Reload,&WatchReload::reload);
 
     if (engine.rootObjects().isEmpty())
         return -1;

--- a/src/watchreload/watchreload.cpp
+++ b/src/watchreload/watchreload.cpp
@@ -1,6 +1,6 @@
 #include <QDebug>
+
 #include "watchreload.h"
-#include "utils.h"
 
 WatchReload::WatchReload(QQmlApplicationEngine *engine)
 {
@@ -14,17 +14,11 @@ void WatchReload::reload()
     qDebug() << "file changes detected";
     if (this->headerObj && this->contentObj) {
 
-        // MACRO set from CMakeLists.txt
-        QString contentPath = WATCH_DIR_PATH;
-        QString headerPath = WATCH_DIR_PATH;
-        headerPath = headerPath.prepend("file:").append("/HeaderComponent.qml");
-        contentPath = contentPath.prepend("file:").append("/ContentComponent.qml");
-
         this->headerObj->setProperty("active",false);
         this->contentObj->setProperty("active",false);
         this->engine->clearComponentCache();
-        this->headerObj->setProperty("source",headerPath);
-        this->contentObj->setProperty("source",contentPath);
+        this->headerObj->setProperty("source","../script/QML/HeaderComponent.qml");
+        this->contentObj->setProperty("source","../script/QML/ContentComponent.qml");
         this->engine->clearComponentCache();
         this->headerObj->setProperty("active",true);
         this->contentObj->setProperty("active",true);
@@ -35,7 +29,7 @@ void WatchReload::reload()
             this->headerObj->setProperty("source","");
 
             // Avoiding incorrectly changes leading it down
-            this->contentObj->setProperty("source","qrc:/ErrorComponent.qml");
+            this->contentObj->setProperty("source","../script/QML/ErrorComponent.qml");
         } else {
             qDebug() << "Application reloaded successfully";
         }


### PR DESCRIPTION
1. in `src/watchreload/watchreload.cpp` file
    use relative path to load corresponding qml file (including the source of ErrorPage.qml, which is a **bug** before)
2. remove redundancy of the code and make the variables more meaningful
3. Let the live-load only available in DEVELOP_MODE 