### PR TITLE
patch-qmllive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ configure_file (
         "${PROJECT_BINARY_DIR}/utils.h"
 )
 
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt5 COMPONENTS Core Quick Qml REQUIRED)
 
 set(EXECUTABLE_FILE ${EXECUTABLE_FILE}
     "src/main.cpp"
@@ -31,4 +31,4 @@ else()
     add_executable(${PROJECT_NAME} ${EXECUTABLE_FILE} "script/qml/qml.qrc")
 endif()
 
-target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Quick)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Quick Qt5::Qml)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Game Hall of Cardirector. This is the Entrance of Cardirector Store.
 + ### features:
   + Refresh your apps automactically when there are changes on QML file. No need to rebuild the whole project in develop mode.
   + *qml.qrc* will not be used when the project is built.
+  + Add log output console support
 + ### Usage:
   + By default, the develop mode is off.
   + You can trigger **DEVELOP_MODE** by using
     ```bash
     cmake -D DEVELOP_MODE=ON $(project_path)
     ```
+  + You can trigger log output console by `F12`, clear log by 'Ctrl + L'

--- a/script/qml/LogCurtain.qml
+++ b/script/qml/LogCurtain.qml
@@ -36,7 +36,7 @@ Flickable { // This is used to let the textedit be scrollable
         activeFocusOnPress: false
         cursorVisible: false
         readOnly: true
-        wrapMode: TextEdit.WordWrap
+        wrapMode: TextEdit.Wrap
         textFormat: TextEdit.AutoText // enable richtext if possible
         visible: false // default is invisible
         Connections {

--- a/script/qml/main.qml
+++ b/script/qml/main.qml
@@ -48,14 +48,14 @@ ApplicationWindow {
 
     Shortcut {
         objectName: "clearlog"
-        enabled: false
+        enabled: true
         sequence: "Ctrl+L"
         onActivated: logloader.item.clearlog()
     }
 
     Shortcut {
         objectName: "showlog"
-        enabled: false
+        enabled: true
         sequence: "F12"
         onActivated: {
             logloader.item.show = !logloader.item.show

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <QDebug>
 #include <QFileSystemWatcher>
 #include <QGuiApplication>
+#include <QtQml>
 #include <QQmlApplicationEngine>
 
 #include "utils.h"
@@ -57,8 +58,6 @@ int main(int argc, char *argv[])
     QObject *showShortCut = engine.rootObjects().first()->findChild<QObject *>("showlog");
     QObject *clearShortCut = engine.rootObjects().first()->findChild<QObject *>("clearlog");
     consoleObj->setProperty("source",consolePath);
-    showShortCut->setProperty("enabled",true);
-    clearShortCut->setProperty("enabled",true);
 
     WatchReload reloader(&engine);
     QObject::connect(&filewatcher,&QFileSystemWatcher::directoryChanged,&reloader,&WatchReload::reload);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,8 +55,6 @@ int main(int argc, char *argv[])
 
     // make the console and shortcut only available in DEVELOP_MODE
     QObject *consoleObj = engine.rootObjects().first()->findChild<QObject *>("console");
-    QObject *showShortCut = engine.rootObjects().first()->findChild<QObject *>("showlog");
-    QObject *clearShortCut = engine.rootObjects().first()->findChild<QObject *>("clearlog");
     consoleObj->setProperty("source",consolePath);
 
     WatchReload reloader(&engine);


### PR DESCRIPTION
1. fix a package missing on ubuntu platform #27 
2. fix #28  (let qml control the shortcut enabled status)
3. modify the wrap mode to be more human-friendly
4. fix #29 